### PR TITLE
Fix production mode (JS errors on page load when bundling is enabled)

### DIFF
--- a/src/main/frontend/src/app/bakery-app.html
+++ b/src/main/frontend/src/app/bakery-app.html
@@ -1,6 +1,11 @@
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
 <link rel="import" href="style-modules/shared-styles.html">
+
+<!--
+Due to the Flow issue https://github.com/vaadin/flow/issues/1754 an import of
+the bakery-navigation.html file is injected dynamically from Java code.
 <link rel="import" href="bakery-navigation.html">
+-->
 
 <dom-module id="bakery-app">
   <template>


### PR DESCRIPTION
Key changes:
 - let Flow add an HTML import for the bakery-navigation.html and remove an explicit import from the bakery-app.html template

This fix is a missing part that should have been added together with the commit bd063c7. That commit extracted bakery-navigation into a separate bundle to work around the Flow issue https://github.com/vaadin/flow/issues/1754.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/90)
<!-- Reviewable:end -->
