### PR TITLE
Disable flow-data pkg from vaadin metapackage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,10 @@
                     <groupId>com.vaadin</groupId>
                     <artifactId>flow-server-production-mode</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>flow-data</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- remove from here after new spring extension is fixed -->


### PR DESCRIPTION
- vaadin 10-SNAPSHOT brought flow-data 1.0-SNAPSHOT, which apparently
broke our build whichs is using flow 0.1.22 packages

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/150)
<!-- Reviewable:end -->
