### PR TITLE
fix laggy paper-ripple animation in the navigation toolbar (#159)

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/BakeryNavigation.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/BakeryNavigation.java
@@ -117,6 +117,13 @@ public class BakeryNavigation extends PolymerTemplate<BakeryNavigation.Model> im
 	}
 
 	@ClientDelegate
+	private void navigateTo(String href) {
+		if (href != null) {
+			getUI().ifPresent(ui -> ui.navigateTo(href));
+		}
+	}
+
+	@ClientDelegate
 	private void logout() {
 		UI ui = getUI().get();
 		History history = ui.getPage().getHistory();

--- a/src/main/webapp/src/app/bakery-navigation.html
+++ b/src/main/webapp/src/app/bakery-navigation.html
@@ -47,7 +47,7 @@
         height: 100%;
       }
 
-      paper-tab a {
+      .navigation-label {
         /* These mixins (from iron-flex-layout) center the link text. */
         @apply --layout-vertical;
         @apply --layout-center-center;
@@ -62,11 +62,11 @@
         margin-bottom: var(--valo-space-xs);
       }
 
-      paper-tab.iron-selected a iron-icon {
+      paper-tab.iron-selected iron-icon {
         color: var(--valo-primary-color);
       }
 
-      paper-tab.iron-selected a span {
+      paper-tab.iron-selected span {
         color: var(--valo-body-text-color);
       }
 
@@ -116,7 +116,7 @@
           padding: 0 var(--valo-space-m);
         }
 
-        paper-tab a {
+        .navigation-label {
           padding: 0 var(--valo-space-xs);
         }
 
@@ -130,13 +130,13 @@
       }
 
       @media (min-width: 740px) {
-        paper-tab a {
+        .navigation-label {
           padding: 0 var(--valo-space-m);
         }
       }
 
       @media (min-width: 920px) {
-        paper-tab a {
+        .navigation-label {
           padding: 0 var(--valo-space-l);
         }
       }
@@ -152,13 +152,14 @@
           Sunshine
         </div>
 
-        <paper-tabs selected="[[page]]" attr-for-selected="page-id" class="navigation-tabs" align-bottom="[[_desktopView]]">
+        <paper-tabs selected="[[page]]" attr-for-selected="page-id" on-transitionend="_onNavAnimationEnd"
+                    class="navigation-tabs" align-bottom="[[_desktopView]]">
           <template is="dom-repeat" items="[[pages]]">
-            <paper-tab page-id="[[item.link]]">
-              <a router-link href="[[item.link]]">
+            <paper-tab page-id$="[[item.link]]">
+              <div class="navigation-label">
                 <iron-icon icon="valo:[[item.icon]]"></iron-icon>
                 <span>[[item.title]]</span>
-              </a>
+              </div>
             </paper-tab>
           </template>
         </paper-tabs>
@@ -224,6 +225,23 @@
       
       _logout() {
         this.$server.logout();
+      }
+
+      // Navigation should be implemented with plain <a router-link href="..."></a> elements.
+      // However, when done that way it causes the paper-ripple animation on the navigation paper-tabs to be laggy
+      // (see https://github.com/Polymer/paper-ripple/issues/10 for details).
+      // Hence this workaround: wait for the paper-ripple animation to finish, and then trigger navigation manually.
+      _onNavAnimationEnd(event) {
+        const pageId = event.target.getAttribute('page-id');
+        this._debouncer = Polymer.Debouncer.debounce(
+          this._debouncer,
+          Polymer.Async.timeOut.after(30),
+          () => {
+            if (this.page !== pageId) {
+              this.$server.navigateTo(pageId);
+            }
+          }
+        );
       }
     }
 

--- a/src/test/java/com/vaadin/starter/bakery/AbstractIT.java
+++ b/src/test/java/com/vaadin/starter/bakery/AbstractIT.java
@@ -87,7 +87,7 @@ public class AbstractIT extends TestBenchTestCase {
 	 * 
 	 *         * @throws TimeoutException If 10 seconds passed.
 	 */
-	protected WebElement waitUntilElementPresent(By by) {
+	protected WebElement waitUntilElementPresent(org.openqa.selenium.By by) {
 		return new WebDriverWait(getDriver(), 10).until(ExpectedConditions.presenceOfElementLocated(by));
 	}
 }

--- a/src/test/java/com/vaadin/starter/bakery/ui/UsersViewIT.java
+++ b/src/test/java/com/vaadin/starter/bakery/ui/UsersViewIT.java
@@ -14,9 +14,10 @@ public class UsersViewIT extends AbstractIT {
 
 	private UsersViewElement openTestPage() {
 		openLoginView().login("admin@vaadin.com", "admin");
-		WebElement usersNavLink = findElement(By.shadowSelector("bakery-app::shadow bakery-navigation::shadow a[href='users']"));
+		WebElement usersNavLink = findElement(By.shadowSelector("bakery-app::shadow bakery-navigation::shadow paper-tab[page-id='users']"));
 		usersNavLink.click();
-		return ((TestBenchElement) findElement(By.tagName("bakery-users"))).wrap(UsersViewElement.class);
+		WebElement usersViewElement = waitUntilElementPresent(By.tagName("bakery-users"));
+		return ((TestBenchElement) usersViewElement).wrap(UsersViewElement.class);
 	}
 
 	@Test


### PR DESCRIPTION
* fix laggy paper-ripple animation in the navigation toolbar

See https://github.com/Polymer/paper-ripple/issues/10 for details on the paper-ripple issue. At the moment it looks like the easiest way to work it around is to let the animation finish (smoothly) before initiating a navigation that consumes CPU and makes the animation appear laggy when running in parallel.

* fix tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/168)
<!-- Reviewable:end -->
