### PR TITLE
fix the order edit view broken in Firefox after the commit #9b4aada

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/components/storefront/OrderEditWrapper.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/components/storefront/OrderEditWrapper.java
@@ -39,8 +39,12 @@ public class OrderEditWrapper extends PolymerTemplate<OrderEditWrapper.Model> {
 	}
 
 	public void openEdit(Order order, User currentUser, Collection<Product> availableProducts) {
-		// no-op if orderEdit is already a child of `this`
-		addToSlot(this, orderEdit, "detail-dialog");
+		// This is a workaround for a Safari 11 issue.
+		// If the orderEdit is injected into the page in the OrderEditWrapper constructor,
+		// Safari fails to set the styles correctly.
+		if (orderEdit.getElement().getParent() == null) {
+			addToSlot(this, orderEdit, "detail-dialog");
+		}
 
 		this.order = order;
 		orderEdit.init(currentUser, availableProducts);
@@ -62,8 +66,12 @@ public class OrderEditWrapper extends PolymerTemplate<OrderEditWrapper.Model> {
 	}
 
 	private void review() {
-		// no-op if orderDetail is already a child of `this`
-		addToSlot(this, orderDetail, "detail-dialog");
+		// This is a workaround for a Safari 11 issue.
+		// If the orderDetail is injected into the page in the OrderEditWrapper constructor,
+		// Safari fails to set the styles correctly.
+		if (orderDetail.getElement().getParent() == null) {
+			addToSlot(this, orderDetail, "detail-dialog");
+		}
 
 		final boolean review = true;
 		orderDetail.display(order, review);


### PR DESCRIPTION
It looks like a Firefox issue: if a custom element is removed from the DOM and then immediately inserted again, Firefox calls the element's disconnectedCallback() twice. In this case it was happening when the `<order-edit>` element was re-inserted as a child of the `<order-edit-wrapper>`.

Jira: BFF-297

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/170)
<!-- Reviewable:end -->
