### PR TITLE
Re-enable ES5 build so that Bakery works in IE11

### DIFF
--- a/src/main/webapp/polymer.json
+++ b/src/main/webapp/polymer.json
@@ -1,5 +1,5 @@
 {
-  "entrypoint": "src/storefront/bakery-storefront.html",
+  "entrypoint": "src/app/bakery-app.html",
   "shell": "src/app/bakery-app.html",
   "sources": [
     "src/**/*",
@@ -15,6 +15,13 @@
     "rules": ["polymer-2"]
   },
   "builds": [
+    {
+      "name": "es5",
+      "js": { "minify": true, "compile": true },
+      "css": { "minify": true },
+      "html": { "minify": true },
+      "bundle": true
+    },
     {
       "name": "es6",
       "js": { "minify": true, "compile": false },


### PR DESCRIPTION
This PR makes it again possible to view Bakery with IE11, and that reveals a lot of IE-specific UI issues: https://protools.atlassian.net/browse/BFF-314?jql=labels%20%3D%20IE11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/182)
<!-- Reviewable:end -->
