### PR TITLE
align dirty-checking behavior with that of Binder::hasChanges()

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/components/storefront/OrderEdit.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/components/storefront/OrderEdit.java
@@ -86,7 +86,7 @@ public class OrderEdit extends PolymerTemplate<OrderEdit.Model> implements HasTo
 	public OrderEdit() {
 		addToSlot(this, items, "order-items-edit");
 
-		cancel.addClickListener(e -> fireEvent(new CancelEvent(binder.hasChanges() || items.hasChanges())));
+		cancel.addClickListener(e -> fireEvent(new CancelEvent(hasChanges())));
 		review.addClickListener(e -> {
 			try {
 				binder.writeBean(this.order);
@@ -124,9 +124,13 @@ public class OrderEdit extends PolymerTemplate<OrderEdit.Model> implements HasTo
 		binder.forField(items).bind("items");
 		items.addPriceChangeListener(e -> setTotalPrice(e.getTotalPrice()));
 
-		items.addListener(OrderItemsEdit.ValueChangeEvent.class, e -> review.setDisabled(false));
+		items.addListener(OrderItemsEdit.ValueChangeEvent.class, e -> review.setDisabled(!hasChanges()));
 		items.addListener(OrderItemsEdit.NewEditorEvent.class, e -> updateDesktopViewOnItemsEdit());
-		binder.addValueChangeListener(e -> review.setDisabled(false));
+		binder.addValueChangeListener(e -> review.setDisabled(!hasChanges()));
+	}
+
+	private boolean hasChanges() {
+		return binder.hasChanges() || items.hasChanges();
 	}
 
 	private void updateDesktopViewOnItemsEdit() {


### PR DESCRIPTION
Currently Binder::hasChanges() returns true after the first property change even if consequent changes would undo the edits. There is an open ticket to change that behavior but it's not implemented yet (see https://github.com/vaadin/framework/issues/9360). When that ticket is closed, Bakery's dirty-checking should be reconsidered.

Jira: BFF-265

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/183)
<!-- Reviewable:end -->
