### PR TITLE
ensure the order edit form stays dirty when pressing 'Back' on review

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/components/storefront/OrderEdit.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/components/storefront/OrderEdit.java
@@ -83,6 +83,8 @@ public class OrderEdit extends PolymerTemplate<OrderEdit.Model> implements HasTo
 
 	private Order order;
 
+	private boolean initialHasChanges;
+
 	private User currentUser;
 
 	private BeanValidationBinder<Order> binder = new BeanValidationBinder<>(Order.class);
@@ -153,8 +155,12 @@ public class OrderEdit extends PolymerTemplate<OrderEdit.Model> implements HasTo
 		binder.addValueChangeListener(e -> review.setDisabled(!hasChanges()));
 	}
 
+	public void setInitialHasChanges(boolean initialHasChanges) {
+		this.initialHasChanges = initialHasChanges;
+	}
+
 	private boolean hasChanges() {
-		return binder.hasChanges() || items.hasChanges();
+		return initialHasChanges || binder.hasChanges() || items.hasChanges();
 	}
 
 	private void updateDesktopViewOnItemsEdit() {
@@ -175,6 +181,7 @@ public class OrderEdit extends PolymerTemplate<OrderEdit.Model> implements HasTo
 
 	public void setEditableItem(Order order) {
 		this.order = order;
+		this.initialHasChanges = false;
 		getModel().setOpened(true);
 		binder.readBean(order);
 		boolean newOrder = order.getId() == null;

--- a/src/main/java/com/vaadin/starter/bakery/ui/components/storefront/OrderEditWrapper.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/components/storefront/OrderEditWrapper.java
@@ -34,7 +34,7 @@ public class OrderEditWrapper extends PolymerTemplate<OrderEditWrapper.Model> {
 	public OrderEditWrapper(ProductService productService, UserService userService) {
 		orderEdit.addCancelListener(e -> fireEvent(new CancelEvent(e.hasChanges())));
 		orderEdit.addReviewListener(e -> this.details(true));
-		orderDetail.addBackListener(e -> this.edit());
+		orderDetail.addBackListener(e -> this.edit(true));
 		orderDetail.addSaveListener(e -> fireEvent(new SaveEvent()));
 		orderDetail.addEditListener(
 				e -> openEdit(order, userService.getCurrentUser(), productService.getRepository().findAll()));
@@ -53,7 +53,7 @@ public class OrderEditWrapper extends PolymerTemplate<OrderEditWrapper.Model> {
 		orderEdit.init(currentUser, availableProducts);
 		orderEdit.setEditableItem(order);
 		getModel().setOpened(true);
-		edit();
+		edit(false);
 	}
 
 	public void openDetails(Order order) {
@@ -68,7 +68,8 @@ public class OrderEditWrapper extends PolymerTemplate<OrderEditWrapper.Model> {
 		getModel().setOpened(false);
 	}
 
-	private void edit() {
+	private void edit(boolean initialHasChanges) {
+		orderEdit.setInitialHasChanges(initialHasChanges);
 		orderEdit.getElement().setAttribute("hidden", false);
 		orderDetail.getElement().setAttribute("hidden", true);
 	}


### PR DESCRIPTION
In order to pass the order data from the OrderEdit to the OrderDetails component, the changes need to be saved into the order object with Binder::writeBean(). That resets the 'has changes' flag in the binder, so when the OrderEdit components gets displayed again after pressing the 'Back' button, it looks as a clean form. To counter that there is now an additional 'initialHasChanges' boolean flag in the OrderEdit component.

NOTE: I've looking for a possibly better way to implement dirty-checking and order data passing between the editor and viewer components (see the [Slack thread](https://vaadin.slack.com/archives/C6X43FE8M/p1507635287000035)). Any suggestions are welcome.

Jira: BFF-296

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/185)
<!-- Reviewable:end -->
