### PR TITLE
fix the login view layout in IE11

### DIFF
--- a/src/main/webapp/src/login/bakery-login.html
+++ b/src/main/webapp/src/login/bakery-login.html
@@ -53,7 +53,7 @@
       .login {
         padding: var(--valo-space-l);
         background-color: var(--valo-base-color);
-        flex: 1;
+        flex: 1 0 auto;
       }
 
       .login__header {
@@ -75,6 +75,7 @@
         margin-left: 0;
         margin-right: 0;
         position: relative;
+        min-width: 7em;
       }
 
       .login__button-icon {
@@ -91,6 +92,7 @@
       .error__icon {
         flex: 0 0 auto;
         width: 1em;
+        height: 1em;
         fill: var(--valo-error-color);
         margin-top: 1.3em;
         margin-right: var(--valo-space-s);


### PR DESCRIPTION
Fix 3 issues:
 - the white area in the login block should extend enough downwards to include the username / password fields
 - the Sign In button should have all the text visible
 - the error message should not stretch the login block more than necessary, the error icon should be aligned with the text

Before:
<img width="526" alt="image" src="https://user-images.githubusercontent.com/22416150/31758929-257c2bfa-b4b8-11e7-8707-149cc1c43297.png">

After:
<img width="525" alt="image" src="https://user-images.githubusercontent.com/22416150/31758883-ec3add8c-b4b7-11e7-9e5b-3919591481e0.png">

Jira: BFF-314

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/207)
<!-- Reviewable:end -->
