### PR TITLE
fix the order edit dialog position in IE11

### DIFF
--- a/src/main/webapp/src/elements/confirm-dialog.html
+++ b/src/main/webapp/src/elements/confirm-dialog.html
@@ -8,6 +8,7 @@
       :host #fore {
         max-width: 400px;
         max-height: 200px;
+        width: 100%;
         margin: auto;
         left: 16px;
         right: 16px;

--- a/src/main/webapp/src/elements/item-detail-dialog.html
+++ b/src/main/webapp/src/elements/item-detail-dialog.html
@@ -13,6 +13,7 @@
       :host([desktop-view]) #fore {
         min-width: 500px;
         max-width: 680px;
+        width: 100%;
       }
 
       :host([desktop-view]:not([side])) #fore {


### PR DESCRIPTION
Fix 2 issues:
 - the order edit dialog should not be stuck to the left edge of the screen
 - the confirmation dialog should not be stuck to the left edge of the screen

Before:
<img width="950" alt="image" src="https://user-images.githubusercontent.com/22416150/31766286-ca68157c-b4cf-11e7-9832-87330c044f4c.png">

After:
<img width="950" alt="image" src="https://user-images.githubusercontent.com/22416150/31766313-e40807d0-b4cf-11e7-829b-4d4b345f3576.png">

Jira: BFF-321

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/208)
<!-- Reviewable:end -->
