### PR TITLE
Update tests for changes in TestBench

### DIFF
--- a/src/test/java/com/vaadin/starter/bakery/AbstractIT.java
+++ b/src/test/java/com/vaadin/starter/bakery/AbstractIT.java
@@ -31,7 +31,7 @@ public abstract class AbstractIT extends TestBenchTestCase {
 	@Before
 	public void setup() {
 		setDriver(createDriver());
-		getDriver().resizeViewPortTo(1024, 768);
+		getCommandExecutor().resizeViewPortTo(1024, 768);
 	}
 
 	protected WebDriver createDriver() {


### PR DESCRIPTION
Method resizeViewPortTo is no longer available in the driver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/220)
<!-- Reviewable:end -->
