### PR TITLE
avoid JS error on login in browsers without native Custom Elements API

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/app/CustomBootstrapListener.java
+++ b/src/main/java/com/vaadin/starter/bakery/app/CustomBootstrapListener.java
@@ -11,7 +11,11 @@ public class CustomBootstrapListener implements BootstrapListener {
 			// Force login page to use Shady DOM to avoid problems with browsers and
 			// password managers not supporting shadow DOM
 			head.prepend(
-					"<script type='text/javascript'>window.customElements.forcePolyfill=true;window.ShadyDOM = {force:true};</script>");
+					"<script type='text/javascript'>" +
+							"window.customElements=window.customElements||{};" +
+							"window.customElements.forcePolyfill=true;" +
+							"window.ShadyDOM={force:true};" +
+					"</script>");
 		}
 		addFavIconTags(head);
 		injectInlineCustomStyles(head);


### PR DESCRIPTION
fixes the "Unable to set property 'forcePolyfill' of undefined or null reference" error in the browser console

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/248)
<!-- Reviewable:end -->
