### PR TITLE
fix ITests failures on Travis "unknown error: Chrome failed to start: crashed"

### DIFF
--- a/src/test/java/com/vaadin/starter/bakery/AbstractIT.java
+++ b/src/test/java/com/vaadin/starter/bakery/AbstractIT.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.starter.bakery.ui.view.LoginViewElement;
@@ -35,7 +36,10 @@ public abstract class AbstractIT extends TestBenchTestCase {
 	}
 
 	protected WebDriver createDriver() {
-		return TestBench.createDriver(new ChromeDriver());
+		// Trying the workaround described here: https://github.com/SeleniumHQ/selenium/issues/4961
+		ChromeOptions options = new ChromeOptions();
+		options.addArguments("--no-sandbox");
+		return TestBench.createDriver(new ChromeDriver(options));
 	}
 
 	@Override


### PR DESCRIPTION
add the '--no-sandbox' option to Chrome based on the discussion in https://github.com/SeleniumHQ/selenium/issues/4961 to avoid consistent test failures appeared lately

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/307)
<!-- Reviewable:end -->
