### PR TITLE
Revert workaround for running tests in travis

### DIFF
--- a/src/test/java/com/vaadin/starter/bakery/AbstractIT.java
+++ b/src/test/java/com/vaadin/starter/bakery/AbstractIT.java
@@ -4,7 +4,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.starter.bakery.ui.view.LoginViewElement;
@@ -36,9 +35,7 @@ public abstract class AbstractIT extends TestBenchTestCase {
 	}
 
 	protected WebDriver createDriver() {
-		// A workaround for the 'Chrome failed to start: crashed' error when running tests in Travis
-		// (see https://github.com/SeleniumHQ/selenium/issues/4961)
-		return TestBench.createDriver(new ChromeDriver(new ChromeOptions().addArguments("--no-sandbox")));
+		return TestBench.createDriver(new ChromeDriver());
 	}
 
 	@Override


### PR DESCRIPTION
Revert 0ea956a as it's not needed anymore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/315)
<!-- Reviewable:end -->
