### PR TITLE
add 'bakery-page-loaded' custom performance mark to the Dashboard view

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,12 +135,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-charts-flow</artifactId>
-            <version>6.0.0.alpha6</version>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-charts-webjar</artifactId>
-            <version>6.0.0-alpha7</version>
+            <version>6.0.0.alpha10</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/src/main/webapp/frontend/bower.json
+++ b/src/main/webapp/frontend/bower.json
@@ -17,7 +17,7 @@
     "paper-toast": "^2.0.0",
     "vaadin": "vaadin/vaadin#10.0.0-alpha8",
     "vaadin-grid": "vaadin/vaadin-grid#4.1.0-beta1",
-    "vaadin-charts": "vaadin/vaadin-charts#6.0.0-alpha7",
+    "vaadin-charts": "vaadin/vaadin-charts#6.0.0-alpha10",
     "vaadin-valo-theme": "vaadin/vaadin-valo-theme#2.0.0-alpha5"
   },
   "devDependencies": {
@@ -26,7 +26,7 @@
   "private": true,
   "resolutions": {
     "vaadin-grid": "4.1.0-beta1",
-    "vaadin-charts": "6.0.0-alpha7",
+    "vaadin-charts": "6.0.0-alpha10",
     "vaadin-valo-theme": "2.0.0-alpha5"
   }
 }

--- a/src/main/webapp/frontend/src/dashboard/bakery-dashboard.html
+++ b/src/main/webapp/frontend/src/dashboard/bakery-dashboard.html
@@ -88,6 +88,32 @@
       static get is() {
         return 'bakery-dashboard';
       }
+
+      // This method is overridden to measure the page load performance and can be safely removed
+      // if there is no need for that.
+      ready() {
+        super.ready();
+        this._chartsLoaded = new Promise((resolve, reject) => {
+          // save the 'resolve' callback to trigger it later from the server
+          this._chartsLoadedResolve = () => {
+            resolve();
+          };
+        });
+
+        this._gridLoaded = new Promise((resolve, reject) => {
+          const listener = () => {
+            if (!this.$['orders-grid'].loading) {
+              this.$['orders-grid'].removeEventListener('loading-changed', listener);
+              resolve();
+            }
+          };
+          this.$['orders-grid'].addEventListener('loading-changed', listener);
+        });
+
+        Promise.all([this._chartsLoaded, this._gridLoaded]).then(() => {
+          window.performance.mark('bakery-page-loaded');
+        });
+      }
     }
 
     window.customElements.define(BakeryDashboard.is, BakeryDashboard);


### PR DESCRIPTION
The 'bakery-page-loaded' mark is set at the point when the grid and all charts are loaded. In Chrome 64 that seems to happen _after_ the 'Time to Consistently Interactive' metric.
 - the 'grid loaded' event is approximated by the change of the grid's 'loading' property (to be replaced with a more accurate solution when https://github.com/vaadin/vaadin-grid/issues/1158 is fixed)
 - the 'charts loaded' event is reported by HighCharts

Jira: BFF-437

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/343)
<!-- Reviewable:end -->
