### PR TITLE
remove unused .grid-wrapper class from the bakery-storefront template

### DIFF
--- a/src/main/webapp/frontend/src/storefront/bakery-storefront.html
+++ b/src/main/webapp/frontend/src/storefront/bakery-storefront.html
@@ -30,12 +30,6 @@
         -webkit-overflow-scrolling: touch;
       }
 
-      .grid-wrapper {
-        flex: 1;
-        height: 100%;
-        position: relative;
-      }
-
       #storefront-grid {
         max-width: 100%;
       }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/364)
<!-- Reviewable:end -->
