### PR TITLE
Re-enable test blocked by BFF-339

### DIFF
--- a/src/test/java/com/vaadin/starter/bakery/testbench/StorefrontViewIT.java
+++ b/src/test/java/com/vaadin/starter/bakery/testbench/StorefrontViewIT.java
@@ -1,7 +1,6 @@
 package com.vaadin.starter.bakery.testbench;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.vaadin.starter.bakery.testbench.elements.components.StorefrontOrderCardElement;
@@ -30,7 +29,6 @@ public class StorefrontViewIT extends AbstractIT {
 		Assert.assertTrue(firstOrder.isOrderSelected());
 	}
 
-	@Ignore("until the issue BFF-339 is fixed")
 	@Test
 	public void editOrder() {
 		StorefrontViewElement storefrontPage = openStorefrontPage();
@@ -44,7 +42,7 @@ public class StorefrontViewIT extends AbstractIT {
 
 		Assert.assertFalse(firstOrder.isOrderSelected());
 
-		Assert.assertTrue(getDriver().getCurrentUrl().endsWith("edit"));
+		Assert.assertTrue(getDriver().getCurrentUrl().endsWith("edit="));
 	}
 
 }

--- a/src/test/java/com/vaadin/starter/bakery/testbench/elements/components/OrderDetailsFullElement.java
+++ b/src/test/java/com/vaadin/starter/bakery/testbench/elements/components/OrderDetailsFullElement.java
@@ -12,7 +12,7 @@ public class OrderDetailsFullElement extends TestBenchElement {
 	}
 
 	public ButtonElement getEditButton() {
-		return $(ButtonElement.class).id("edit-order-detail");
+		return $(ButtonElement.class).id("edit");
 	}
 
 }


### PR DESCRIPTION
Re-enabled a test that was marked as ignored because of BFF-339, since that task is now closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/375)
<!-- Reviewable:end -->
