### PR TITLE
change the 'production' maven profile to work better with spring-boot:run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <node.version>v8.1.2</node.version>
         <yarn.version>v0.27.5</yarn.version>
         <buildtools.directory>build-tools</buildtools.directory>
-        <frontend.directory>src/main/webapp/frontend</frontend.directory>
+        <webapp.directory>src/main/webapp</webapp.directory>
     </properties>
 
     <repositories>
@@ -250,6 +250,11 @@
                     <version>${maven.war.plugin.version}</version>
                 </plugin>
                 <plugin>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>flow-maven-plugin</artifactId>
+                    <version>${flow.maven.plugin.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
                     <version>${frontend.maven.plugin.version}</version>
@@ -264,27 +269,20 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+
         <plugins>
-            <!-- (1): Configures the cleanup process for JS dependencies
-                and build -->
+            <!-- (1): Clean up the flow-maven-plugin build output from the
+                  webapp folder where it's copied to for spring-boot:run -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>${frontend.directory}/build</directory>
+                            <directory>${webapp.directory}/frontend-es5</directory>
                         </fileset>
                         <fileset>
-                            <directory>${frontend.directory}/bower_components</directory>
-                        </fileset>
-                        <fileset>
-                            <directory>${frontend.directory}</directory>
-                            <includes>
-                                <include>grid-flow-component-renderer.html</include>
-                                <include>flow-component-renderer.html</include>
-                                <include>gridConnector.js</include>
-                            </includes>
+                            <directory>${webapp.directory}/frontend-es6</directory>
                         </fileset>
                     </filesets>
                 </configuration>
@@ -298,45 +296,6 @@
 
     <profiles>
         <profile>
-            <id>lint</id>
-            <activation>
-                <property>
-                    <name>runLint</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.eirslett</groupId>
-                        <artifactId>frontend-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>install-node-and-yarn</id>
-                                <goals>
-                                    <goal>install-node-and-yarn</goal>
-                                    <goal>yarn</goal> <!-- runs 'install' by default -->
-                                </goals>
-                                <configuration>
-                                    <workingDirectory>${buildtools.directory}</workingDirectory>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>yarn run lint</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>yarn</goal>
-                                </goals>
-                                <configuration>
-                                    <arguments>run lint</arguments>
-                                    <workingDirectory>${buildtools.directory}</workingDirectory>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>production</id>
             <activation>
                 <property>
@@ -344,63 +303,77 @@
                 </property>
             </activation>
 
-            <properties>
-                <yarn.build.goal>run build</yarn.build.goal>
-            </properties>
-
-
-            <!-- (2): Makes the package run in production mode when deployed, without the need of setting extra
-                      properties on the server -->
+            <!-- (2): Make the package run in production mode when deployed as .war,
+                      without the need of setting extra properties on the server -->
             <dependencies>
                 <dependency>
                     <groupId>com.vaadin</groupId>
                     <artifactId>flow-server-production-mode</artifactId>
                 </dependency>
             </dependencies>
+
             <build>
                 <plugins>
-                    <!-- (3): Configures the frontend plugin to compile the web components 
-                        source -->
+                    <!-- (3): Run flow-maven-plugin to transpile and optimize frontend code -->
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
-                        <version>${flow.maven.plugin.version}</version>
                         <executions>
                             <execution>
                                 <goals>
                                     <goal>copy-production-files</goal>
                                     <goal>package-for-production</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- (4): Copy the output of flow-maven-plugin into the webapp folder,
+                         which is the root of the servlet context if the app starts via spring-boot:run -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-frontend-build-for-spring-boot-run</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
                                 <configuration>
-                                    <transpileOutputDirectory>${frontend.directory}/build</transpileOutputDirectory>
-                                    <transpileWorkingDirectory>${project.build.directory}/transpile</transpileWorkingDirectory>
-                                    <transpileEs6SourceDirectory>${project.build.directory}/transpile</transpileEs6SourceDirectory>
-                                    <copyOutputDirectory>${project.build.directory}/transpile</copyOutputDirectory>
-                                    <bundle>true</bundle>
+                                    <outputDirectory>${webapp.directory}</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.build.directory}/${project.build.finalName}</directory>
+                                            <includes>
+                                                <include>frontend-es5/**</include>
+                                                <include>frontend-es6/**</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
                                 </configuration>
                             </execution>
                         </executions>
                     </plugin>
 
-
-                    <!-- (4): Include bundled files in war. -->
+                    <!-- (5): Exclude the unprocessed frontend sources from the .war file -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-war-plugin</artifactId>
                         <configuration>
-                            <webResources>
-                                <resource>
-                                    <directory>${frontend.directory}/build</directory>
-                                </resource>
-                            </webResources>
-                            <warSourceExcludes>**/build/,**/bower.json,**/package.json,.bowerrc,src/**,bower_components/**,frontend/**</warSourceExcludes>
+                            <warSourceExcludes>frontend/**,.gitignore</warSourceExcludes>
                         </configuration>
                     </plugin>
+
+                    <!-- (6): Pass the 'production mode' setting to the spring boot app.
+                         NOTE: This forks the JVM. If there is a need to debug the production mode,
+                               remove the jvmArguments parameter from pom.xml and add
+                               '-Dvaadin.productionMode' to the `mvn spring-boot:run` command line -->
                     <plugin>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
-                            <jvmArguments>-Dvaadin.frontend.url.es5=context://frontend/build/frontend-es5/ -Dvaadin.frontend.url.es6=context://frontend/build/frontend-es6/ -Dvaadin.productionMode</jvmArguments>
+                            <jvmArguments>-Dvaadin.productionMode</jvmArguments>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -481,6 +454,47 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>lint</id>
+            <activation>
+                <property>
+                    <name>runLint</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>install-node-and-yarn</id>
+                                <goals>
+                                    <goal>install-node-and-yarn</goal>
+                                    <goal>yarn</goal> <!-- runs 'install' by default -->
+                                </goals>
+                                <configuration>
+                                    <workingDirectory>${buildtools.directory}</workingDirectory>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>yarn run lint</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>run lint</arguments>
+                                    <workingDirectory>${buildtools.directory}</workingDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <!-- For running Gatling tests -->
             <id>scalability</id>

--- a/src/main/java/com/vaadin/starter/bakery/app/security/SecurityConfiguration.java
+++ b/src/main/java/com/vaadin/starter/bakery/app/security/SecurityConfiguration.java
@@ -126,13 +126,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				"/images/**",
 
 				// (development mode) static resources
-				"/frontend/bower_components/**",
-				"/frontend/images/**",
-				"/frontend/src/**",
-
-				// (development mode) resources from the framework jars
-				"/frontend/*.html",
-				"/frontend/*.js",
+				"/frontend/**",
 
 				// (development mode) webjars
 				"/webjars/**",
@@ -140,10 +134,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				// (development mode) H2 debugging console
 				"/h2-console/**",
 
-				// (production mode) static resources - for mvn spring-boot:run
-				"/frontend/build/**",
-
-				// (production mode) static resources - for .war deployments (e.g. Tomcat)
+				// (production mode) static resources
 				"/frontend-es5/**", "/frontend-es6/**");
 	}
 }

--- a/src/main/webapp/.gitignore
+++ b/src/main/webapp/.gitignore
@@ -1,0 +1,2 @@
+frontend-es5
+frontend-es6

--- a/src/main/webapp/frontend/.gitignore
+++ b/src/main/webapp/frontend/.gitignore
@@ -1,6 +1,0 @@
-# unpacked from flow-server.jar by `mvn install -Dvaadin.productionMode`
-flow-component-renderer.html
-
-# unpacked from vaadin-grid-flow.jar by `mvn install -Dvaadin.productionMode`
-flow-grid-component-renderer.html
-gridConnector.js


### PR DESCRIPTION
(now restarting the app in the production mode via `mvn spring-boot:run -Dvaadin.productionMode` works)

The structure of the resulting .war file has changed to be as expected by Flow by default:
 - the transpiled ES5 frontend sources are in /frontend-es5 (were in /frontend/build/frontend-es5)
 - the transpiled ES6 frontend sources are in /frontend-es6 (were in /frontend/build/frontend-es6)
 - there is no need to set custom locations for the transpiled frontend assets in Flow
 - to be able to run the app via the Spring Boot Maven plugin, the transpiled assets are copied also to the webapp folder (which is the context root in that case)

fixes Jira: BFF-615

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/430)
<!-- Reviewable:end -->
