### PR TITLE
Fix orders button-bar partially covered in mobile

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/views/storefront/OrderEditor.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/views/storefront/OrderEditor.java
@@ -1,7 +1,6 @@
 package com.vaadin.starter.bakery.ui.views.storefront;
 
 import static com.vaadin.starter.bakery.ui.dataproviders.DataProviderUtil.createItemLabelGenerator;
-import static com.vaadin.starter.bakery.ui.utils.TemplateUtil.addToSlot;
 
 import java.time.LocalTime;
 import java.util.SortedSet;
@@ -19,6 +18,7 @@ import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.polymertemplate.Id;
 import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
@@ -88,6 +88,9 @@ public class OrderEditor extends PolymerTemplate<OrderEditor.Model> {
 	@Id("review")
 	private Button review;
 
+	@Id("itemsContainer")
+	private Div itemsContainer;
+
 	private OrderItemsEditor items;
 
 	private User currentUser;
@@ -99,7 +102,8 @@ public class OrderEditor extends PolymerTemplate<OrderEditor.Model> {
 	@Autowired
 	public OrderEditor(PickupLocationDataProvider locationProvider, ProductDataProvider productDataProvider) {
 		items = new OrderItemsEditor(productDataProvider);
-		addToSlot(this, "order-items-editor", items);
+
+		itemsContainer.add(items);
 
 		cancel.addClickListener(e -> fireEvent(new CancelEvent(this, false)));
 		review.addClickListener(e -> fireEvent(new ReviewEvent(this)));

--- a/src/main/webapp/frontend/src/components/form-buttons-bar.html
+++ b/src/main/webapp/frontend/src/components/form-buttons-bar.html
@@ -8,7 +8,6 @@
     <buttons-bar>
       <vaadin-button id="save" slot="left" on-click="_save" theme="raised primary" disabled="[[saveDisabled]]">[[saveText]]</vaadin-button>
       <vaadin-button id="cancel" slot="left" on-click="_cancel" theme="raised" disabled="[[cancelDisabled]]">[[cancelText]]</vaadin-button>
-      <div style="flex: 1"></div>
       <vaadin-button id="delete" slot="right" on-click="_delete" theme="raised tertiary error" disabled="[[deleteDisabled]]">[[deleteText]]</vaadin-button>
     </buttons-bar>
   </template>

--- a/src/main/webapp/frontend/src/views/storefront/order-editor.html
+++ b/src/main/webapp/frontend/src/views/storefront/order-editor.html
@@ -69,8 +69,8 @@
 
           <vaadin-form-item colspan="3">
             <label slot="label">Products</label>
-            <slot name="order-items-editor"></slot>
           </vaadin-form-item>
+          <div id="itemsContainer" colspan="3"></div>
 
         </vaadin-form-layout>
       </vaadin-form-layout>


### PR DESCRIPTION
Slotted div added to order-editor was causing layout problems
because it is visible. Since it is not necessary to use addSlot
hack, removing it in favor of simpler dom manipulation.

Jira: BFF-582

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/440)
<!-- Reviewable:end -->
