### PR TITLE
Fix order-details layout issues

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/views/storefront/StorefrontView.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/views/storefront/StorefrontView.java
@@ -61,8 +61,6 @@ public class StorefrontView extends PolymerTemplate<TemplateModel>
 		searchBar.setCheckboxText("Show past orders");
 		searchBar.setPlaceHolder("Search");
 
-		dialog.add(orderDetails);
-
 		grid.setSelectionMode(Grid.SelectionMode.SINGLE);
 		grid.addColumn(new ComponentRenderer<>(order -> {
 			OrderCard orderCard = new OrderCard();
@@ -150,9 +148,7 @@ public class StorefrontView extends PolymerTemplate<TemplateModel>
 	}
 
 	void setDialogElementsVisibility(boolean editing) {
-		if (editing) {
-			dialog.add(orderEditor);
-		}
+		dialog.add(editing ? orderEditor : orderDetails);
 		orderEditor.setVisible(editing);
 		orderDetails.setVisible(!editing);
 	}


### PR DESCRIPTION
When order-details is opened after editor, form-layout does not get notified and it has a wrong size.
By lazy attaching the view, layout is computed correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/472)
<!-- Reviewable:end -->
