### PR TITLE
Add a name tag for the project name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <artifactId>bakery-app-starter-flow-spring</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>war</packaging>
+    <name>Bakery for Flow and Spring</name>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>


### PR DESCRIPTION
Resolves generator issues where the first `<name>` content is replaced by the project name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/502)
<!-- Reviewable:end -->
