### PR TITLE
Remove unused send tab key

### DIFF
--- a/src/test/java/com/vaadin/starter/bakery/testbench/UsersViewIT.java
+++ b/src/test/java/com/vaadin/starter/bakery/testbench/UsersViewIT.java
@@ -53,7 +53,7 @@ public class UsersViewIT extends AbstractIT {
 		// Saving any field without changing password should save and close
 		TextFieldElement emailField = usersView.getEmailField();
 		emailField.setValue("foo" + r.nextInt() + "@bar.com");
-		emailField.sendKeys(Keys.TAB);
+
 		usersView.getButtonsBar().getSaveButton().click();
 
 		Assert.assertFalse(usersView.getDialog().isOpen());
@@ -62,7 +62,7 @@ public class UsersViewIT extends AbstractIT {
 		bakerCell.click();
 		emailField.setValue(uniqueEmail);
 		password.setValue("123");
-		password.sendKeys(Keys.TAB);
+
 		usersView.getButtonsBar().getSaveButton().click();
 		NotificationElement toast = $(NotificationElement.class).first();
 		Assert.assertTrue(form.isDisplayed());


### PR DESCRIPTION
SendKey method causes 'element is not reachable by keyboard' in Firefox on linux. Moreover sendKey tab is not needed since setValue makes blur.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/512)
<!-- Reviewable:end -->
