### PR TITLE
Fix login layout for IE 11

### DIFF
--- a/src/main/webapp/frontend/src/views/login/login-view.html
+++ b/src/main/webapp/frontend/src/views/login/login-view.html
@@ -100,7 +100,7 @@
         max-width: 35em;
       }
 
-      @media (max-height: 400px) {
+      @media (max-height: 450px) {
         .info__header {
           margin-top: 0;
         }
@@ -110,8 +110,9 @@
         }
       }
 
-      @media (min-width: 750px) and (min-height: 400px) {
+      @media (min-width: 750px) and (min-height: 450px) {
         .container {
+          display: block;
           border-radius: 4px;
           max-width: 700px;
           overflow: hidden;


### PR DESCRIPTION
- IE 11 isn't calculating the height of a flex container when height is set to `auto`. Change the container to block for desktop seems to fix the issue.
- Update height breakpoint to change earlier to mobile layout because it creates more room for the error message.

JIRA: BFF-688

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/565)
<!-- Reviewable:end -->
