### PR TITLE
Make buttons-bar buttons show on Safari 9 on iPhone

### DIFF
--- a/src/main/webapp/frontend/src/components/buttons-bar.html
+++ b/src/main/webapp/frontend/src/components/buttons-bar.html
@@ -32,6 +32,7 @@
         :host ::slotted([slot=info]) {
           order: -1;
           min-width: 100%;
+          flex-basis: 100%;
         }
       }
     </style>


### PR DESCRIPTION
Fixes #566 

Workaround for bug in Safari 9 https://bugs.webkit.org/show_bug.cgi?id=136041

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/568)
<!-- Reviewable:end -->
