### PR TITLE
Style div inside the flow-component-renderer with dialog-flow API

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/crud/CrudView.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/crud/CrudView.java
@@ -58,6 +58,8 @@ public abstract class CrudView<E extends AbstractEntity, T extends TemplateModel
 
 		dialog.add((Component) getForm());
 		// Workaround for https://github.com/vaadin/vaadin-dialog-flow/issues/28
+
+		dialog.setHeight("100%");
 		dialog.getElement().addAttachListener(event ->
 				UI.getCurrent().getPage().executeJavaScript(
 						"$0.$.overlay.setAttribute('theme', 'right');", dialog.getElement()));

--- a/src/main/webapp/frontend/src/views/admin/products/product-form.html
+++ b/src/main/webapp/frontend/src/views/admin/products/product-form.html
@@ -11,6 +11,7 @@
         display: flex;
         flex-direction: column;
         flex: auto;
+        height: 100%;
       }
 
       vaadin-form-layout {

--- a/src/main/webapp/frontend/src/views/admin/users/user-form.html
+++ b/src/main/webapp/frontend/src/views/admin/users/user-form.html
@@ -13,6 +13,7 @@
         display: flex;
         flex-direction: column;
         flex: auto;
+        height: 100%;
       }
 
       vaadin-form-layout {

--- a/src/main/webapp/frontend/styles/shared-styles.html
+++ b/src/main/webapp/frontend/styles/shared-styles.html
@@ -64,12 +64,9 @@
         }
       }
 
-      /* dialog-flow introduces two wrappers that we need to flex */
-      flow-component-renderer,
-      flow-component-renderer > div {
-        display: flex;
-        flex-direction: column;
-        flex: auto;
+      /* we need explicitly set height for wrappers inside dialog-flow */
+      ::slotted(flow-component-renderer) {
+        height: 100%;
       }
     </style>
   </template>


### PR DESCRIPTION
Flow-component-renderer now is placed in light DOM, so it's impossible to style the div inside, except of using dialog-flow API.

BFF-699

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/580)
<!-- Reviewable:end -->
