### PR TITLE
Mark storefront view dirty once review dialog was displayed

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/views/orderedit/OrderDetails.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/views/orderedit/OrderDetails.java
@@ -62,6 +62,8 @@ public class OrderDetails extends PolymerTemplate<OrderDetails.Model> {
 	@Id("commentField")
 	private TextField commentField;
 
+	private boolean isDirty;
+
 	public OrderDetails() {
 		sendComment.addClickListener(e -> {
 			String message = commentField.getValue();
@@ -83,6 +85,15 @@ public class OrderDetails extends PolymerTemplate<OrderDetails.Model> {
 		if (!review) {
 			commentField.clear();
 		}
+		this.isDirty = review;
+	}
+
+	public boolean isDirty() {
+		return isDirty;
+	}
+
+	public void setDirty(boolean isDirty) {
+		this.isDirty = isDirty;
 	}
 
 	public interface Model extends TemplateModel {

--- a/src/main/java/com/vaadin/starter/bakery/ui/views/storefront/StorefrontView.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/views/storefront/StorefrontView.java
@@ -122,7 +122,7 @@ public class StorefrontView extends PolymerTemplate<TemplateModel>
 
 	@Override
 	public boolean isDirty() {
-		return orderEditor.hasChanges();
+		return orderEditor.hasChanges() || orderDetails.isDirty();
 	}
 
 	@Override
@@ -152,6 +152,7 @@ public class StorefrontView extends PolymerTemplate<TemplateModel>
 
 	@Override
 	public void clear() {
+		orderDetails.setDirty(false);
 		orderEditor.clear();
 	}
 


### PR DESCRIPTION
After user reached review dialog we have to assume it is dirty even if user went back for editing

BFF-701

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/585)
<!-- Reviewable:end -->
