### PR TITLE
Crop data labels on pie chart

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/views/dashboard/DashboardView.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/views/dashboard/DashboardView.java
@@ -140,6 +140,7 @@ public class DashboardView extends PolymerTemplate<TemplateModel> {
 				.map(e -> new DataSeriesItem(e.getKey().getName(), e.getValue())).collect(Collectors.toList()));
 		PlotOptionsPie plotOptionsPie = new PlotOptionsPie();
 		plotOptionsPie.setInnerSize("60%");
+		plotOptionsPie.getDataLabels().setCrop(false);
 		deliveriesPerProductSeries.setPlotOptions(plotOptionsPie);
 		conf.addSeries(deliveriesPerProductSeries);
 	}


### PR DESCRIPTION
If labels are too long, chart was being shift. With this, labels is cropped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/587)
<!-- Reviewable:end -->
