### PR TITLE
Remove Webjars' bintrap repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,6 @@
         </repository>
 
         <repository>
-            <id>webjars-bintray</id>
-            <url>https://dl.bintray.com/webjars/maven/</url>
-        </repository>
-
-        <repository>
             <id>vaadin-addons</id>
             <url>http://maven.vaadin.com/vaadin-addons</url>
         </repository>


### PR DESCRIPTION
Because webjars.org publish artifacts to MavenCentral also, so projects should be able to run without extra repos defined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/592)
<!-- Reviewable:end -->
