### PR TITLE
Use spring-boot-dependencies bom instead of parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,6 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Bakery for Flow and Spring</name>
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.RELEASE</version>
-        <relativePath /> <!-- lookup parent from repository -->
-    </parent>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -22,6 +16,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <!-- Dependencies -->
         <vaadin.version>10.0.0.beta10</vaadin.version>
+        <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
 
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <!-- Overrides the old version specified by the Spring Boot parent -->
@@ -68,6 +63,13 @@
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-bom</artifactId>
                 <version>${vaadin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This reduces active repositories from 6 to 3
Currently we have:
* vaadin-prereleases
* vaadin-addons
* spring-snapshot
* spring-milestone
* rabbit-milestone
* central

After the change it will be:
* vaadin-prereleases
* vaadin-addons
* central

It will be 2 after stable release of vaadin 10:
* vaadin-addons
* central

Fixes #545

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/593)
<!-- Reviewable:end -->
