### PR TITLE
Revert "Use spring-boot-dependencies bom instead of parent"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,12 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Bakery for Flow and Spring</name>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.0.0.RELEASE</version>
+        <relativePath /> <!-- lookup parent from repository -->
+    </parent>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -16,7 +22,6 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <!-- Dependencies -->
         <vaadin.version>10.0.0.beta10</vaadin.version>
-        <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
 
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <!-- Overrides the old version specified by the Spring Boot parent -->
@@ -63,13 +68,6 @@
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-bom</artifactId>
                 <version>${vaadin.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Reverts vaadin/bakery-app-starter-flow-spring#593

Usage of `spring-boot-dependencies` makes it quite hard to override dependencies.

For example with selenium bom overrides 10 dependencies from `org.seleniumhq.selenium` with `selenium.version` and all of those should be overriden individually if we want to use the bom. Which can be done with a single line while using the parent pom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/595)
<!-- Reviewable:end -->
