### PR TITLE
Adds IDE setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ mvn clean
 ```
 before running in the other mode.
 
+# Running in Eclipse or IntelliJ
+As both IDEs support running Spring Boot applications you just have to import the project and select `com.vaadin.starter.bakery.Application` as main class if not done automatically. Using an IDE will also allow you to speed up development even more. Just check https://vaadin.com/blog/developing-without-server-restarts.
+
+## IntelliJ < 2018
+Unfortunately, up to IntelliJ 2017 dependencies scoped as `provided` in the Maven POM will not be loaded on startup. As a workaround you will have to remove the scope definition of `spring-boot-starter-tomcat` and `javax.servlet-api` from the pom.xml.
+
 # Running Scalability Tests
 
 The Bakery App Starter includes scalability tests. Once you have deployed a production build of Bakery you can run them to check how the app behaves under load. The scalability tests can be run completely on your local machine, but you might as well want to run locally only the test agents while the Bakery app under test is deployed to an environment that is close to your production.


### PR DESCRIPTION
As discussed with @oluwasayo I added a section to the readme that describes the use of an IDE and describes a workaround for IntelliJ < 2018 and the provided scope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/599)
<!-- Reviewable:end -->
