### PR TITLE
Avoid sharing data provider instances  platform 10 (#665)

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/dataproviders/OrdersGridDataProvider.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/dataproviders/OrdersGridDataProvider.java
@@ -7,8 +7,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -18,15 +16,16 @@ import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.provider.QuerySortOrder;
 import com.vaadin.flow.data.provider.QuerySortOrderBuilder;
 import com.vaadin.flow.spring.annotation.SpringComponent;
+import com.vaadin.flow.spring.annotation.UIScope;
 import com.vaadin.starter.bakery.backend.data.entity.Order;
 import com.vaadin.starter.bakery.backend.service.OrderService;
 import com.vaadin.starter.bakery.ui.utils.BakeryConst;
 
 /**
- * A singleton pageable order data provider.
+ * A pageable order data provider.
  */
 @SpringComponent
-@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@UIScope
 public class OrdersGridDataProvider extends FilterablePageableDataProvider<Order, OrdersGridDataProvider.OrderFilter> {
 
 	public static class OrderFilter implements Serializable {

--- a/src/main/java/com/vaadin/starter/bakery/ui/dataproviders/PickupLocationDataProvider.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/dataproviders/PickupLocationDataProvider.java
@@ -8,13 +8,15 @@ import org.springframework.data.domain.PageRequest;
 import com.vaadin.flow.data.provider.AbstractBackEndDataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.spring.annotation.SpringComponent;
+import com.vaadin.flow.spring.annotation.UIScope;
 import com.vaadin.starter.bakery.backend.data.entity.PickupLocation;
 import com.vaadin.starter.bakery.backend.service.PickupLocationService;
 
 /**
- * A singleton data provider which knows which pickup locations are available.
+ * A data provider which knows which pickup locations are available.
  */
 @SpringComponent
+@UIScope
 public class PickupLocationDataProvider extends AbstractBackEndDataProvider<PickupLocation, String> {
 
 	private transient PickupLocationService pickupLocationService;

--- a/src/main/java/com/vaadin/starter/bakery/ui/dataproviders/ProductDataProvider.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/dataproviders/ProductDataProvider.java
@@ -7,10 +7,12 @@ import org.springframework.data.domain.PageRequest;
 import com.vaadin.flow.data.provider.AbstractBackEndDataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.spring.annotation.SpringComponent;
+import com.vaadin.flow.spring.annotation.UIScope;
 import com.vaadin.starter.bakery.backend.data.entity.Product;
 import com.vaadin.starter.bakery.backend.service.ProductService;
 
 @SpringComponent
+@UIScope
 public class ProductDataProvider extends AbstractBackEndDataProvider<Product, String> {
 
 	private final ProductService productService;


### PR DESCRIPTION
Sharing the same data provider between multiple UIs can be dangerous
because of the way each component registers a listener to the data
provider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/666)
<!-- Reviewable:end -->
