### PR TITLE
Explicitly define Central as the first repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,18 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>vaadin-addons</id>
             <url>http://maven.vaadin.com/vaadin-addons</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
 


### PR DESCRIPTION
When additional repositories are defined in pom.xml, Maven will look for each dependency there first before falling back to Central. Since most of the dependencies needed for building Bakery are in Central, it would be faster (especially with an empty local Maven cache) if Maven would check Central before any custom repository.
Closes #722

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/726)
<!-- Reviewable:end -->
