### PR TITLE
Fix old CRUD TODOs

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/crud/AbstractBakeryCrudView.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/crud/AbstractBakeryCrudView.java
@@ -96,6 +96,8 @@ public abstract class AbstractBakeryCrudView<E extends AbstractEntity> extends C
                 return;
             }
             entityPresenter.loadEntity(id, entity -> edit(entity, EditMode.EXISTING_ITEM));
+        } else {
+            setOpened(false);
         }
     }
 }


### PR DESCRIPTION
- Use CRUD edit method
- Throw exception on validation failure to avoid closing the editor

One issue is that every time the exception is thrown to block the action, it ends up in the application logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/859)
<!-- Reviewable:end -->
