### PR TITLE
Unify theme for app layout and make tabs scrollable (#866)

### DIFF
--- a/frontend/styles/shared-styles.js
+++ b/frontend/styles/shared-styles.js
@@ -23,6 +23,34 @@ $_documentContainer.innerHTML = `<dom-module id="bakery-app-layout-theme" theme-
           display: none;
         }
       }
+
+      [part="navbar"] {
+        align-items: center;
+        justify-content: center;
+      }
+
+      [part="navbar"]::after {
+        content: '';
+      }
+
+      [part="navbar"] ::slotted(*:first-child),
+      [part="navbar"]::after {
+        flex: 1 0 0.001px;
+      }
+
+      @media (max-width: 800px) {
+        [part="navbar"] ::slotted(vaadin-tabs) {
+          max-width: 100% !important;
+        }
+
+        [part="navbar"] ::slotted(.hide-on-mobile) {
+          display: none;
+        }
+
+        [part="navbar"]::after {
+          content: none;
+        }
+      }
     </style>
   </template>
 </dom-module>
@@ -284,36 +312,6 @@ $_documentContainer.innerHTML = `<dom-module id="bakery-app-layout-theme" theme-
   </template>
 </dom-module>
 
-<dom-module id="app-layout-theme" theme-for="vaadin-app-layout">
-  <template>
-    <style>
-      [part="navbar"] {
-        align-items: center;
-        justify-content: center;
-      }
-
-      [part="navbar"]::after {
-        content: '';
-      }
-
-      [part="navbar"] ::slotted(*:first-child),
-      [part="navbar"]::after {
-        flex: 1 0 0.001px;
-      }
-
-      @media (max-width: 425px) {
-        [part="navbar"] ::slotted(.hide-on-mobile) {
-          display: none;
-        }
-
-        [part="navbar"]::after {
-          content: none;
-        }
-    }
-    </style>
-  </template>
-</dom-module>
-
 <custom-style>
   <style>
     @keyframes v-progress-start {
@@ -412,6 +410,10 @@ $_documentContainer.innerHTML = `<dom-module id="bakery-app-layout-theme" theme-
       height: var(--lumo-icon-size-m);
       padding: .25rem;
       box-sizing: border-box !important;
+    }
+
+    vaadin-app-layout vaadin-tabs {
+      max-width: 65%;
     }
 
     @media (min-width: 700px) {

--- a/src/main/java/com/vaadin/starter/bakery/ui/MainView.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/MainView.java
@@ -59,7 +59,8 @@ public class MainView extends AppLayout {
 
 		menu = createMenuTabs();
 
-		this.addToNavbar(true, appName, menu);
+		this.addToNavbar(appName);
+		this.addToNavbar(true, menu);
 		this.getElement().appendChild(confirmDialog.getElement());
 
 		getElement().addEventListener("search-focus", e -> {


### PR DESCRIPTION
* Merge the two themes for app-layout

* Fix scrolling and unify breakpoints with app-layout

Only add menu as touchOptimized
Set max-width for menu and make it full width in small viewports

* Fix eslint issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/871)
<!-- Reviewable:end -->
