### PR TITLE
Remove unnecessary workaround

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/MainView.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/MainView.java
@@ -46,9 +46,6 @@ public class MainView extends AppLayout {
 	private final Tabs menu;
 
 	public MainView() {
-		// Workaround for https://github.com/vaadin/flow/issues/5792
-		new OfflineBanner();
-
 		confirmDialog.setCancelable(true);
 		confirmDialog.setConfirmButtonTheme("raised tertiary error");
 		confirmDialog.setCancelButtonTheme("raised tertiary");


### PR DESCRIPTION
The mentioned issue has been fixed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/910)
<!-- Reviewable:end -->
