### PR TITLE
Change dist to xenial (#935)

### DIFF
--- a/.travis.script.sh
+++ b/.travis.script.sh
@@ -7,4 +7,4 @@
 
 TESTBENCH=-Dvaadin.proKey=$VAADIN_PRO_KEY
 
-mvn -B -e -V clean verify -DrunLint -Pit,production -Dvaadin.bowerMode=false $TESTBENCH
+xvfb-run  --server-args="-screen 0 1024x768x24" mvn -B -e -V clean verify -DrunLint -Pit,production -Dvaadin.bowerMode=false $TESTBENCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 sudo: true
-dist: trusty
+dist: xenial
 
 # Make it possible to run tests on a local Chrome
 before_install:
  - export CHROME_BIN=/usr/bin/google-chrome
- - export DISPLAY=:99.0
- - sh -e /etc/init.d/xvfb start
-# The Following line fixes random Chrome startup failures (https://github.com/SeleniumHQ/docker-selenium/issues/87)
- - export DBUS_SESSION_BUS_ADDRESS=/dev/null
 
 addons:
   apt:

--- a/webdrivers.xml
+++ b/webdrivers.xml
@@ -2,10 +2,10 @@
 <root>
     <windows>
         <driver id="googlechrome">
-            <version id="75.0.3770.140">
+            <version id="77.0.3865.40">
                 <bitrate thirtytwobit="true" sixtyfourbit="true">
-                    <filelocation>http://chromedriver.storage.googleapis.com/75.0.3770.140/chromedriver_win32.zip</filelocation>
-                    <hash>643862ffe1adafd1eefc251704fa417f7331144a</hash>
+                    <filelocation>http://chromedriver.storage.googleapis.com/77.0.3865.40/chromedriver_win32.zip</filelocation>
+                    <hash>c367947ec475e436e34f3f9c4864ae3659867c6e</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -13,10 +13,10 @@
     </windows>
     <linux>
         <driver id="googlechrome">
-            <version id="75.0.3770.140">
+            <version id="77.0.3865.40">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/75.0.3770.140/chromedriver_linux64.zip</filelocation>
-                    <hash>e83ebe6d91c27736173fb1aa2f39e98169ee5788</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/77.0.3865.40/chromedriver_linux64.zip</filelocation>
+                    <hash>1776fe8449489fa98e4fe80255ed3874f94d0dee</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -24,10 +24,10 @@
     </linux>
     <osx>
         <driver id="googlechrome">
-            <version id="75.0.3770.140">
+            <version id="77.0.3865.40">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/75.0.3770.140/chromedriver_mac64.zip</filelocation>
-                    <hash>f6512038646e05328a70ff136619134e7ce0ad41</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/77.0.3865.40/chromedriver_mac64.zip</filelocation>
+                    <hash>bc5d502044c86fbba20614df317cc2194d19aa86</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>


### PR DESCRIPTION
Google has dropped Trusty support for Chrome

Change to openjdk8 as oraclejdk8 is not available

Update webdrivers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/938)
<!-- Reviewable:end -->
