### PR TITLE
Update com.saucelabs.maven.plugin to 2.1.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,7 @@
                             <dependency>
                                 <groupId>com.saucelabs</groupId>
                                 <artifactId>ci-sauce</artifactId>
-                                <version>1.138</version>
+                                <version>1.144</version>
                             </dependency>
                             <dependency>
                                 <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
2.1.25 contains the the dependency for com.saucelabs » ci-sauce for version 1.144.

This should handle the Bender problem "Response: {"error": "Your Sauce Connect version (4.4.2) is no longer supported (4.4.12 or newer required). Please download the latest version from https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy."}.
[14:40:06][Step 3/3] 18 Sep 11:40:06 - Error creating tunnel."

(https://mvnrepository.com/artifact/com.saucelabs.maven.plugin/sauce-connect-plugin/2.1.25)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/941)
<!-- Reviewable:end -->
