### PR TITLE
Update com.saucelabs.maven.plugin to 2.1.25 (#941)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,24 @@
                     <plugin>
                         <groupId>com.saucelabs.maven.plugin</groupId>
                         <artifactId>sauce-connect-plugin</artifactId>
-                        <version>2.1.23</version>
+                        <version>2.1.25</version>
+                        <configuration>
+                            <sauceUsername>${sauce.user}</sauceUsername>
+                            <sauceAccessKey>${sauce.sauceAccessKey}</sauceAccessKey>
+                            <options>${sauce.options}</options>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.saucelabs</groupId>
+                                <artifactId>ci-sauce</artifactId>
+                                <version>1.144</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>javax.xml.bind</groupId>
+                                <artifactId>jaxb-api</artifactId>
+                                <version>2.3.0</version>
+                            </dependency>
+                        </dependencies>
                         <executions>
                             <!-- Start Sauce Connect prior to running the integration tests -->
                             <execution>
@@ -483,13 +500,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>javax.xml.bind</groupId>
-                                <artifactId>jaxb-api</artifactId>
-                                <version>2.3.0</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
* Update com.saucelabs.maven.plugin to 2.1.25

2.1.25 contains the the dependency for com.saucelabs » ci-sauce for version 1.144.

* Also update ci-sauce

(cherry picked from commit a8c07d7cc3d0820169e1ae02d300695db308478e)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/946)
<!-- Reviewable:end -->
