### PR TITLE
Cherrypick #942 Fix NPE

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/app/security/SecurityUtils.java
+++ b/src/main/java/com/vaadin/starter/bakery/app/security/SecurityUtils.java
@@ -40,10 +40,12 @@ public final class SecurityUtils {
 	 */
 	public static String getUsername() {
 		SecurityContext context = SecurityContextHolder.getContext();
-		Object principal = context.getAuthentication().getPrincipal();
-		if(principal instanceof UserDetails) {
-			UserDetails userDetails = (UserDetails) context.getAuthentication().getPrincipal();
-			return userDetails.getUsername();
+		if (context != null && context.getAuthentication() != null) {
+			Object principal = context.getAuthentication().getPrincipal();
+			if(principal instanceof UserDetails) {
+				UserDetails userDetails = (UserDetails) context.getAuthentication().getPrincipal();
+				return userDetails.getUsername();
+			}
 		}
 		// Anonymous or no authentication.
 		return null;


### PR DESCRIPTION
Cherrypick #942 Fix NPE

Caused by: java.lang.NullPointerException: null
	at org.vaadin.haijian.app.security.SecurityUtils.getUsername(SecurityUtils.java:43) ~[classes/:na]
	at org.vaadin.haijian.app.security.SecurityConfiguration.currentUser(SecurityConfiguration.java:61) ~[classes/:na]
	at org.vaadin.haijian.app.security.SecurityConfiguration$$EnhancerBySpringCGLIB$$a3327ef7.CGLIB$currentUser$5(<generated>) ~[classes/:na]
	at org.vaadin.haijian.app.security.SecurityConfiguration$$EnhancerBySpringCGLIB$$a3327ef7$$FastClassBySpringCGLIB$$dba18071.invoke(<generated>) ~[classes/:na]
	at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:244) ~[spring-core-5.1.9.RELEASE.jar:5.1.9.RELEASE]
	at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:363) ~[spring-context-5.1.9.RELEASE.jar:5.1.9.RELEASE]
	at org.vaadin.haijian.app.security.SecurityConfiguration$$EnhancerBySpringCGLIB$$a3327ef7.currentUser(<generated>) ~[classes/:na]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_181]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_181]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_181]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_181]
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:154) ~[spring-beans-5.1.9.RELEASE.jar:5.1.9.RELEASE]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/951)
<!-- Reviewable:end -->
