### PR TITLE
Add mention about the `production` profile (#1080)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Note that when running in development mode, the application will not work in IE1
 
 # Running Integration Tests and Linter
 
-Integration tests are implemented using TestBench. The tests take tens of minutes to run and are therefore included in a separate profile. To run the tests, execute
+Integration tests are implemented using TestBench. The tests take tens of minutes to run and are therefore included in a separate profile. We recommend running tests with a production build to minimize the chance of development time toolchains affecting test stability. To run the tests, execute
 
-`mvn verify -Pit`
+`mvn verify -Pit,production`
 
 and make sure you have a valid TestBench license installed.
 


### PR DESCRIPTION
Until https://github.com/vaadin/testbench/issues/1244 is fixed, tests must be run with production profile enable.

Co-authored-by: Thomas Mattsson <thomas@vaadin.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/1084)
<!-- Reviewable:end -->
