### PR TITLE
fix: do not automatically allow requests with `Referer: /sw.js` header

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/app/security/CustomRequestCache.java
+++ b/src/main/java/com/vaadin/starter/bakery/app/security/CustomRequestCache.java
@@ -19,9 +19,12 @@ class CustomRequestCache extends HttpSessionRequestCache {
 	 */
 	@Override
 	public void saveRequest(HttpServletRequest request, HttpServletResponse response) {
-		if (!SecurityUtils.isFrameworkInternalRequest(request)) {
+		String referer = request.getHeader("Referer");
+		boolean isServiceWorkInitiated =
+				referer != null && referer.endsWith("sw.js");
+		if (!SecurityUtils.isFrameworkInternalRequest(request)
+				&& !isServiceWorkInitiated) {
 			super.saveRequest(request, response);
 		}
 	}
-
 }

--- a/src/main/java/com/vaadin/starter/bakery/app/security/SecurityUtils.java
+++ b/src/main/java/com/vaadin/starter/bakery/app/security/SecurityUtils.java
@@ -110,11 +110,10 @@ public final class SecurityUtils {
 	 * @return true if is an internal framework request. False otherwise.
 	 */
 	static boolean isFrameworkInternalRequest(HttpServletRequest request) {
-		final String parameterValue = request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER);
-		String referer = request.getHeader("Referer");
-		boolean isServiceWorkInitiated = (referer!=null && referer.endsWith("sw.js"));
-		return isServiceWorkInitiated || parameterValue != null
-				&& Stream.of(RequestType.values()).anyMatch(r -> r.getIdentifier().equals(parameterValue));
+		final String parameterValue = request
+				.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER);
+		return parameterValue != null && Stream.of(RequestType.values())
+				.anyMatch(r -> r.getIdentifier().equals(parameterValue));
 	}
 
 }


### PR DESCRIPTION
Instead, use it only in the `CustomRequestCache` logic for ignoring a request.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bakery-app-starter-flow-spring/1160)
<!-- Reviewable:end -->
