### PR TITLE
refactor: use proper layout for user and product view

### DIFF
--- a/frontend/src/components/search-bar.js
+++ b/frontend/src/components/search-bar.js
@@ -24,6 +24,7 @@ class SearchBar extends LitElement {
         order: 1;
         width: 100%;
         height: 48px;
+        box-sizing: border-box;
       }
 
       .row {

--- a/frontend/themes/bakery/components/vaadin-crud.css
+++ b/frontend/themes/bakery/components/vaadin-crud.css
@@ -2,21 +2,7 @@
   height: 100%;
 }
 
-#new {
-  display: none;
-}
-
-[part="toolbar"] {
-  padding: 0 !important;
-}
-
 :host ::slotted(vaadin-grid) {
   max-width: calc(964px + var(--lumo-space-m));
   background-color: var(--lumo-base-color);
-}
-
-@media (min-width: 700px) {
-  [part="toolbar"] {
-    order: -1;
-  }
 }

--- a/src/main/java/com/vaadin/starter/bakery/ui/views/admin/products/ProductsView.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/views/admin/products/ProductsView.java
@@ -37,6 +37,11 @@ public class ProductsView extends AbstractBakeryCrudView<Product> {
 	}
 
 	@Override
+	protected Product createItem() {
+		return new Product();
+	}
+
+	@Override
 	protected void setupGrid(Grid<Product> grid) {
 		grid.addColumn(Product::getName).setHeader("Product Name").setFlexGrow(10);
 		grid.addColumn(p -> currencyFormatter.encode(p.getPrice())).setHeader("Unit Price");

--- a/src/main/java/com/vaadin/starter/bakery/ui/views/admin/users/UsersView.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/views/admin/users/UsersView.java
@@ -38,6 +38,11 @@ public class UsersView extends AbstractBakeryCrudView<User> {
 	}
 
 	@Override
+	protected User createItem() {
+		return new User();
+	}
+
+	@Override
 	public void setupGrid(Grid<User> grid) {
 		grid.addColumn(User::getEmail).setWidth("270px").setHeader("Email").setFlexGrow(5);
 		grid.addColumn(u -> u.getFirstName() + " " + u.getLastName()).setHeader("Name").setWidth("200px").setFlexGrow(5);

--- a/src/test/java/com/vaadin/starter/bakery/testbench/ProductsViewIT.java
+++ b/src/test/java/com/vaadin/starter/bakery/testbench/ProductsViewIT.java
@@ -31,14 +31,14 @@ public class ProductsViewIT extends AbstractIT<ProductsViewElement> {
 		int rowNum = createProduct(productsPage, uniqueName, initialPrice);
 		productsPage.openRowForEditing(rowNum);
 
-		Assert.assertTrue(productsPage.isEditorOpen());
+		Assert.assertTrue(productsPage.getCrud().isEditorOpen());
 		String newValue = "New " + uniqueName;
 		TextFieldElement nameField = productsPage.getProductName();
 		nameField.setValue(newValue);
 
-		productsPage.getEditorSaveButton().click();
-		Assert.assertFalse(productsPage.isEditorOpen());
-		GridElement grid = productsPage.getGrid();
+		productsPage.getCrud().getEditorSaveButton().click();
+		Assert.assertFalse(productsPage.getCrud().isEditorOpen());
+		GridElement grid = productsPage.getCrud().getGrid();
 		Assert.assertEquals(rowNum, grid.getCell(newValue).getRow());
 
 		productsPage.openRowForEditing(rowNum);
@@ -46,8 +46,8 @@ public class ProductsViewIT extends AbstractIT<ProductsViewElement> {
 		nameField = productsPage.getProductName();
 		nameField.setValue(newValue);
 
-		productsPage.getEditorSaveButton().click();
-		Assert.assertFalse(productsPage.isEditorOpen());
+		productsPage.getCrud().getEditorSaveButton().click();
+		Assert.assertFalse(productsPage.getCrud().isEditorOpen());
 		Assert.assertEquals(rowNum, grid.getCell(newValue).getRow());
 	}
 
@@ -64,16 +64,16 @@ public class ProductsViewIT extends AbstractIT<ProductsViewElement> {
 		productsPage.openRowForEditing(rowIndex);
 		Assert.assertTrue(getDriver().getCurrentUrl().length() > url.length());
 
-		Assert.assertTrue(productsPage.isEditorOpen());
+		Assert.assertTrue(productsPage.getCrud().isEditorOpen());
 
 		TextFieldElement price = productsPage.getPrice();
 		Assert.assertEquals(initialPrice, price.getValue());
 
 		price.setValue("123.45");
 
-		productsPage.getEditorSaveButton().click();
+		productsPage.getCrud().getEditorSaveButton().click();
 
-		Assert.assertFalse(productsPage.isEditorOpen());
+		Assert.assertFalse(productsPage.getCrud().isEditorOpen());
 
 		Assert.assertTrue(getDriver().getCurrentUrl().endsWith("products"));
 
@@ -85,25 +85,25 @@ public class ProductsViewIT extends AbstractIT<ProductsViewElement> {
 		// Return initial value
 		price.setValue(initialPrice);
 
-		productsPage.getEditorSaveButton().click();
-		Assert.assertFalse(productsPage.isEditorOpen());
+		productsPage.getCrud().getEditorSaveButton().click();
+		Assert.assertFalse(productsPage.getCrud().isEditorOpen());
 	}
 
 	@Test
 	public void testCancelConfirmationMessage() {
 		ProductsViewElement productsPage = openView();
 
-		productsPage.getNewItemButton().get().click();
-		Assert.assertTrue(productsPage.isEditorOpen());
+		productsPage.getCrud().getNewItemButton().get().click();
+		Assert.assertTrue(productsPage.getCrud().isEditorOpen());
 		productsPage.getProductName().setValue("Some name");
-		productsPage.getEditorCancelButton().click();
+		productsPage.getCrud().getEditorCancelButton().click();
 		Assert.assertEquals(productsPage.getDiscardConfirmDialog().getHeaderText(), "Discard changes");
 	}
 
 	private int createProduct(ProductsViewElement productsPage, String name, String price) {
 		productsPage.getSearchBar().getCreateNewButton().click();
 
-		Assert.assertTrue(productsPage.isEditorOpen());
+		Assert.assertTrue(productsPage.getCrud().isEditorOpen());
 
 		TextFieldElement nameField = productsPage.getProductName();
 		TextFieldElement priceField = productsPage.getPrice();
@@ -111,10 +111,10 @@ public class ProductsViewIT extends AbstractIT<ProductsViewElement> {
 		nameField.setValue(name);
 		priceField.setValue(price);
 
-		productsPage.getEditorSaveButton().click();
-		Assert.assertFalse(productsPage.isEditorOpen());
+		productsPage.getCrud().getEditorSaveButton().click();
+		Assert.assertFalse(productsPage.getCrud().isEditorOpen());
 
-		return waitUntil((ExpectedCondition<GridTHTDElement>) wd -> productsPage.getGrid().getCell(name)).getRow();
+		return waitUntil((ExpectedCondition<GridTHTDElement>) wd -> productsPage.getCrud().getGrid().getCell(name)).getRow();
 	}
 
 }

--- a/src/test/java/com/vaadin/starter/bakery/testbench/UsersViewIT.java
+++ b/src/test/java/com/vaadin/starter/bakery/testbench/UsersViewIT.java
@@ -26,18 +26,18 @@ public class UsersViewIT extends AbstractIT<UsersViewElement> {
 	public void updatePassword() {
 		UsersViewElement usersView = openView();
 
-		Assert.assertFalse(usersView.isEditorOpen());
+		Assert.assertFalse(usersView.getCrud().isEditorOpen());
 
 		String uniqueEmail = "e" + r.nextInt() + "@vaadin.com";
 
 		createUser(usersView, uniqueEmail, "Paul", "Irwin", "Vaadin10", "baker");
 
-		int rowNum = usersView.getGrid().getCell(uniqueEmail).getRow();
+		int rowNum = usersView.getCrud().getGrid().getCell(uniqueEmail).getRow();
 		usersView.openRowForEditing(rowNum);
 
-		Assert.assertTrue(usersView.isEditorOpen());
+		Assert.assertTrue(usersView.getCrud().isEditorOpen());
 
-		Assert.assertTrue(usersView.isEditorOpen());
+		Assert.assertTrue(usersView.getCrud().isEditorOpen());
 
 		// When opening form the password value must be always empty
 		PasswordFieldElement password = usersView.getPasswordField();
@@ -48,11 +48,11 @@ public class UsersViewIT extends AbstractIT<UsersViewElement> {
 		String newEmail = "foo" + r.nextInt() + "@bar.com";
 		emailField.setValue(newEmail);
 
-		usersView.getEditorSaveButton().click();
-		Assert.assertFalse(usersView.isEditorOpen());
+		usersView.getCrud().getEditorSaveButton().click();
+		Assert.assertFalse(usersView.getCrud().isEditorOpen());
 
 		// Invalid password prevents closing form
-		rowNum = usersView.getGrid().getCell(newEmail).getRow();
+		rowNum = usersView.getCrud().getGrid().getCell(newEmail).getRow();
 		usersView.openRowForEditing(rowNum);
 
 		emailField = usersView.getEmailField(); // Requery email field.
@@ -61,19 +61,19 @@ public class UsersViewIT extends AbstractIT<UsersViewElement> {
 		emailField.setValue(uniqueEmail);
 		password.setValue("123");
 
-		usersView.getEditorSaveButton().click();
+		usersView.getCrud().getEditorSaveButton().click();
 
-		Assert.assertTrue(usersView.isEditorOpen());
+		Assert.assertTrue(usersView.getCrud().isEditorOpen());
 
 		password = usersView.getPasswordField(); // Requery password field.
 
 		// Good password
 		password.setValue("Abc123");
-		usersView.getEditorSaveButton().click();
-		Assert.assertFalse(usersView.isEditorOpen());
+		usersView.getCrud().getEditorSaveButton().click();
+		Assert.assertFalse(usersView.getCrud().isEditorOpen());
 
 		// When reopening the form password field must be empty.
-		rowNum = usersView.getGrid().getCell(uniqueEmail).getRow();
+		rowNum = usersView.getCrud().getGrid().getCell(uniqueEmail).getRow();
 		usersView.openRowForEditing(rowNum);
 
 		password = usersView.getPasswordField(); // Requery password field.
@@ -83,7 +83,7 @@ public class UsersViewIT extends AbstractIT<UsersViewElement> {
 	private void createUser(UsersViewElement usersView, String email, String firstName, String lastName,
 			String password, String role) {
 		usersView.getSearchBar().getCreateNewButton().click();
-		Assert.assertTrue(usersView.isEditorOpen());
+		Assert.assertTrue(usersView.getCrud().isEditorOpen());
 
 		usersView.getEmailField().setValue(email);
 		usersView.getFirstName().setValue(firstName);
@@ -92,38 +92,38 @@ public class UsersViewIT extends AbstractIT<UsersViewElement> {
 
 		usersView.getRole().selectByText(role);
 
-		usersView.getEditorSaveButton().click();
-		Assert.assertFalse(usersView.isEditorOpen());
+		usersView.getCrud().getEditorSaveButton().click();
+		Assert.assertFalse(usersView.getCrud().isEditorOpen());
 	}
 
 	@Test
 	public void tryToUpdateLockedEntity() {
 		UsersViewElement page = openView();
 
-		int rowNum = page.getGrid().getCell("barista@vaadin.com").getRow();
+		int rowNum = page.getCrud().getGrid().getCell("barista@vaadin.com").getRow();
 		page.openRowForEditing(rowNum);
 
 		PasswordFieldElement field = page.getPasswordField();
 		field.setValue("Abc123");
 		page.getEmailField().setValue("barista123@vaadin.com");
-		page.getEditorSaveButton().click();
+		page.getCrud().getEditorSaveButton().click();
 
-		Assert.assertEquals(rowNum, page.getGrid().getCell("barista@vaadin.com").getRow());
+		Assert.assertEquals(rowNum, page.getCrud().getGrid().getCell("barista@vaadin.com").getRow());
 	}
 
 	@Test
 	public void tryToDeleteLockedEntity() {
 		UsersViewElement page = openView();
 
-		int rowNum = page.getGrid().getCell("barista@vaadin.com").getRow();
+		int rowNum = page.getCrud().getGrid().getCell("barista@vaadin.com").getRow();
 		page.openRowForEditing(rowNum);
 
-		Assert.assertTrue(page.isEditorOpen());
+		Assert.assertTrue(page.getCrud().isEditorOpen());
 
-		page.getEditorDeleteButton().click();
+		page.getCrud().getEditorDeleteButton().click();
 		page.getDeleteConfirmDialog().getConfirmButton().click();
 
-		Assert.assertEquals(rowNum, page.getGrid().getCell("barista@vaadin.com").getRow());
+		Assert.assertEquals(rowNum, page.getCrud().getGrid().getCell("barista@vaadin.com").getRow());
 	}
 
 	@Test
@@ -131,7 +131,7 @@ public class UsersViewIT extends AbstractIT<UsersViewElement> {
 		UsersViewElement page = openView();
 		page.getSearchBar().getCreateNewButton().click();
 		page.getFirstName().setValue("Some name");
-		page.getEditorCancelButton().click();
+		page.getCrud().getEditorCancelButton().click();
 
 		Assert.assertEquals(page.getDiscardConfirmDialog().getHeaderText(), "Discard changes");
 	}

--- a/src/test/java/com/vaadin/starter/bakery/testbench/elements/ui/BakeryCrudViewElement.java
+++ b/src/test/java/com/vaadin/starter/bakery/testbench/elements/ui/BakeryCrudViewElement.java
@@ -6,25 +6,29 @@ import com.vaadin.flow.component.formlayout.testbench.FormLayoutElement;
 import com.vaadin.starter.bakery.testbench.elements.components.SearchBarElement;
 import com.vaadin.testbench.TestBenchElement;
 
-public class BakeryCrudViewElement extends CrudElement implements HasApp {
+public class BakeryCrudViewElement extends TestBenchElement implements HasApp {
 
 	public SearchBarElement getSearchBar() {
 		return $(SearchBarElement.class).first();
 	}
 
+	public CrudElement getCrud() {
+		return $(CrudElement.class).first();
+	}
+
 	public FormLayoutElement getForm() {
-		return getEditor().$(FormLayoutElement.class).first();
+		return getCrud().getEditor().$(FormLayoutElement.class).first();
 	}
 
 	public ConfirmDialogElement getDiscardConfirmDialog() {
-		return $(ConfirmDialogElement.class).first();
+		return getCrud().$(ConfirmDialogElement.class).first();
 	}
 
 	public ConfirmDialogElement getDeleteConfirmDialog() {
-		return $(ConfirmDialogElement.class).last();
+		return getCrud().$(ConfirmDialogElement.class).last();
 	}
 
 	public void openRowForEditing(int row, int editCol) {
-		getGrid().getCell(row, editCol).$(TestBenchElement.class).first().click();
+		getCrud().getGrid().getCell(row, editCol).$(TestBenchElement.class).first().click();
 	}
 }

--- a/src/test/java/com/vaadin/starter/bakery/testbench/elements/ui/ProductsViewElement.java
+++ b/src/test/java/com/vaadin/starter/bakery/testbench/elements/ui/ProductsViewElement.java
@@ -6,14 +6,13 @@ import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 public class ProductsViewElement extends BakeryCrudViewElement {
 
 	public TextFieldElement getProductName() {
-		return getEditor().$(FormLayoutElement.class).first().$(TextFieldElement.class).first();
+		return getCrud().getEditor().$(FormLayoutElement.class).first().$(TextFieldElement.class).first();
 	}
 
 	public TextFieldElement getPrice() {
-		return getEditor().$(FormLayoutElement.class).first().$(TextFieldElement.class).all().get(1);
+		return getCrud().getEditor().$(FormLayoutElement.class).first().$(TextFieldElement.class).all().get(1);
 	}
 
-	@Override
 	public void openRowForEditing(int row) {
 		openRowForEditing(row, 2);
 	}

--- a/src/test/java/com/vaadin/starter/bakery/testbench/elements/ui/UsersViewElement.java
+++ b/src/test/java/com/vaadin/starter/bakery/testbench/elements/ui/UsersViewElement.java
@@ -27,7 +27,6 @@ public class UsersViewElement extends BakeryCrudViewElement {
 		return getForm().$(ComboBoxElement.class).first();
 	}
 
-	@Override
 	public void openRowForEditing(int row) {
 		openRowForEditing(row, 3);
 	}


### PR DESCRIPTION
## Description

Instead of abusing `Crud` as a layout component, let's use a proper layout component for `UsersView` and `ProductsView`. Instead of wrangling the custom `SearchBar` component into the `Crud`s toolbar, this hides the `Crud` toolbar, and adds the search bar as a separate component.

This fixes the styling issues introduced from upgrading to v24:
![Bildschirmfoto 2023-01-30 um 16 44 48](https://user-images.githubusercontent.com/357820/215524109-1cbe505b-8b8c-4919-8adf-736001982b93.png)
