### PR TITLE
Fix test failures on Windows with Vaadin 25.2

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/ui/crud/AbstractBakeryCrudView.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/crud/AbstractBakeryCrudView.java
@@ -79,9 +79,6 @@ public abstract class AbstractBakeryCrudView<E extends AbstractEntity> extends V
 
     private void setupCrudEventListeners(CrudEntityPresenter<E> entityPresenter) {
         Consumer<E> onSuccess = entity -> navigateToEntity(null);
-        Consumer<E> onFail = entity -> {
-            throw new RuntimeException("The operation could not be performed.");
-        };
 
         crud.addEditListener(e ->
                 entityPresenter.loadEntity(e.getItem().getId(),
@@ -90,10 +87,10 @@ public abstract class AbstractBakeryCrudView<E extends AbstractEntity> extends V
         crud.addCancelListener(e -> navigateToEntity(null));
 
         crud.addSaveListener(e ->
-                entityPresenter.save(e.getItem(), onSuccess, onFail));
+                entityPresenter.save(e.getItem(), onSuccess));
 
         crud.addDeleteListener(e ->
-                entityPresenter.delete(e.getItem(), onSuccess, onFail));
+                entityPresenter.delete(e.getItem(), onSuccess));
     }
 
     protected void navigateToEntity(String id) {

--- a/src/main/java/com/vaadin/starter/bakery/ui/crud/CrudEntityPresenter.java
+++ b/src/main/java/com/vaadin/starter/bakery/ui/crud/CrudEntityPresenter.java
@@ -28,11 +28,23 @@ public class CrudEntityPresenter<E extends AbstractEntity>	implements HasLogger 
 		this.view = view;
 	}
 
+	public void delete(E entity, Consumer<E> onSuccess) {
+		if (executeOperation(() -> crudService.delete(currentUser.getUser(), entity))) {
+			onSuccess.accept(entity);
+		}
+	}
+
 	public void delete(E entity, Consumer<E> onSuccess, Consumer<E> onFail) {
 		if (executeOperation(() -> crudService.delete(currentUser.getUser(), entity))) {
 			onSuccess.accept(entity);
 		} else {
 			onFail.accept(entity);
+		}
+	}
+
+	public void save(E entity, Consumer<E> onSuccess) {
+		if (executeOperation(() -> saveEntity(entity))) {
+			onSuccess.accept(entity);
 		}
 	}
 

--- a/src/test/java/com/vaadin/starter/bakery/testbench/UsersViewIT.java
+++ b/src/test/java/com/vaadin/starter/bakery/testbench/UsersViewIT.java
@@ -12,7 +12,9 @@ import com.vaadin.starter.bakery.testbench.elements.ui.StorefrontViewElement;
 import com.vaadin.starter.bakery.testbench.elements.ui.UsersViewElement;
 import com.vaadin.testbench.BrowserTest;
 import com.vaadin.testbench.TestBenchElement;
+import org.junit.jupiter.api.parallel.Isolated;
 
+@Isolated
 public class UsersViewIT extends AbstractIT<UsersViewElement> {
 
 	private static Random r = new Random();


### PR DESCRIPTION
## Summary

Two test failures on Windows when running against Vaadin 25.2.x. Both pass on Linux.

### AbstractBakeryCrudView: remove exception from onFail callback

`setupCrudEventListeners()` defines `onFail` as a lambda that throws `RuntimeException("The operation could not be performed.")`. In Vaadin 25.2, `vaadin-crud-flow` no longer catches this exception internally, so it escapes through the full request stack and breaks subsequent navigation in the test session.

The exception is unnecessary: `CrudEntityPresenter.executeOperation()` already handles the failure and shows the error notification to the user before calling `onFail`. The callback should be a no-op.

Closes #1500

### UsersViewIT: add @Isolated to prevent concurrent server overload on Windows

On Windows, `UsersViewIT` and `DashboardViewIT` run concurrently (parallelism=2). With Spring Boot 4.x the server is slower to initialize, so concurrent test classes overload it. The login page navigation in `openView()` then exceeds the 10-second `waitForFirst()` timeout.

`@Isolated` prevents `UsersViewIT` from running concurrently with other test classes, giving the server exclusive access during its run.